### PR TITLE
BUG: Allow env without python-tk.

### DIFF
--- a/bayesalpha/model.py
+++ b/bayesalpha/model.py
@@ -19,7 +19,12 @@ from bayesalpha.dists import bspline_basis, GPExponential, NormalNonZero
 from bayesalpha.dists import dot as sparse_dot
 from bayesalpha.serialize import to_xarray
 from bayesalpha._version import get_versions
-from bayesalpha.plotting import plot_horizontal_dots
+try:
+    from bayesalpha.plotting import plot_horizontal_dots
+except ImportError as err:
+    warnings.warn(
+        "plotting unavailable due to the preceding ImportError."
+    )
 
 _PARAM_DEFAULTS = {
     'shrinkage': 'exponential'


### PR DESCRIPTION
When running in a mode which does not generate graphs, the modules supporting
plotting are not needed for import.

Catch and warn when a module required for plotting can not be imported.

This fixes the following exception during import of the baysealpha.
```
  File "/usr/lib/python2.7/lib-tk/Tkinter.py", line 42, in <module>
    raise ImportError, str(msg) + ', please install the python-tk package'
ImportError: No module named _tkinter, please install the python-tk package
```