### PR TITLE
Add cvxpy to requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ pymc3==3.2
 scipy>=0.19.0
 xarray>=0.9
 seaborn
-cvxpy
-
+cvxpy<1.0


### PR DESCRIPTION
So that packaging tooling (in particular, pipenv) will include cvxpy when
installing bayesalpha.