### PR TITLE
ENH Empyrical 0.4.3 only supports cum_returns on series.

### DIFF
--- a/bayesalpha/model.py
+++ b/bayesalpha/model.py
@@ -639,12 +639,12 @@ class FitResult:
         for (chain, sample), point in self._points(include_transformed=False):
             if n_repl is None:
                 returns = predict_func(point).to_pandas().T
-                cum_returns = empyrical.cum_returns_final(returns)
+                cum_returns = returns.apply(empyrical.cum_returns_final)
                 predictions.loc[chain, sample, :] = cum_returns
             else:
                 for repl in repl_coord:
                     returns = predict_func(point).to_pandas().T
-                    cum_returns = empyrical.cum_returns_final(returns)
+                    cum_returns = returns.apply(empyrical.cum_returns_final)
                     predictions.loc[chain, sample, :, repl] = cum_returns
         return predictions
 


### PR DESCRIPTION
This change in empyrical https://github.com/quantopian/empyrical/commit/a39a3233585dda7b11ad31f6ad896f017933d80b#diff-23342a2bf4f4c31bfe2dfe0bcbe54c8bL125 drops support for running `cum_returns` on a DataFrame.