### PR TITLE
REV: remove abc

### DIFF
--- a/bayesalpha/base.py
+++ b/bayesalpha/base.py
@@ -2,11 +2,10 @@
 
 import json
 import hashlib
-from abc import ABC, abstractmethod
 import xarray as xr
 
 
-class BayesAlphaResult(ABC):
+class BayesAlphaResult(object):
     """ A wrapper around a PyMC3 trace as a xarray Dataset. """
 
     def __init__(self, trace):
@@ -20,7 +19,6 @@ class BayesAlphaResult(ABC):
     def _load(cls, trace):
         return cls(trace=trace)
 
-    @abstractmethod
     def rebuild_model(self, **kwargs):
         pass
 


### PR DESCRIPTION
Looks like ABC is new in Py3.4. I'll just remove it for now; it wasn't that important anyways. With the module-level `load` function, I don't think users have any need to use `BayesAlphaResult` directly.