### PR TITLE
PyMC3 3.5 renamed infer_shape to to_tuple

### DIFF
--- a/bayesalpha/dists.py
+++ b/bayesalpha/dists.py
@@ -483,8 +483,8 @@ class EQCorrMvNormal(pm.Continuous):
     @staticmethod
     def st_random(mu, std, corr, clust, size=None, _dist_shape=None):
         mu, std, corr, clust = map(np.asarray, [mu, std, corr, clust])
-        size = pm.distributions.distribution.infer_shape(size)
-        _dist_shape = pm.distributions.distribution.infer_shape(_dist_shape)
+        size = pm.distributions.distribution.to_tuple(size)
+        _dist_shape = pm.distributions.distribution.to_tuple(_dist_shape)
         k = mu.shape[-1]
         if corr.ndim == 1:
             corr = corr[None, :]


### PR DESCRIPTION
https://github.com/pymc-devs/pymc3/commit/1231f910dd4f058c2fa4c3ac6b594faafeec2adc#diff-eb25725602c01ec0a384e4b6d3946331
Closes https://github.com/quantopian/qexec/issues/16091.